### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "angular-app",
     "version": "0.0.2",
     "dependencies": {
-        "angular": "*",
+        "angular": "~1.3.0",
         "angular-i18n": "*",
         "angular-animate": "*",
         "angular-route": "*",


### PR DESCRIPTION
By default it installs 1.2.28 version that will give an error. To fix we can remove everything from vendor dir in git or to set angular version here.
